### PR TITLE
Added middle_element_linked_list.cpp

### DIFF
--- a/Solutions/middle_element_linked_list.cpp
+++ b/Solutions/middle_element_linked_list.cpp
@@ -1,0 +1,50 @@
+#include<bits/stdc++.h>
+using namespace std;
+struct node{
+    int data;
+    node* next;
+};
+void create(struct node** temp,int val)
+{
+    struct node* newnode=new node;
+    newnode->data=val;
+    newnode->next=(*temp);
+    (*temp)=newnode; 
+}
+void mid(struct node* head)
+{
+    int count=0;
+    struct node* mid=head;
+    struct node* temp=head;
+    while(temp!=NULL)
+    {
+        if(count%2!=0)
+        {
+            mid=mid->next;
+        }
+        count++;
+        temp=temp->next;
+    }
+
+    //to print the middle element
+    if(mid!=NULL)
+    {
+        cout<<"The middle element is:"<<mid->data;
+    }
+}
+
+int main()
+{
+    struct node* head=NULL;
+    int n;
+    cin>>n;
+    int arr[n];
+    for(int i=0;i<n;i++)
+    {
+        cin>>arr[i];
+        create(&head,arr[i]);
+    }
+    
+    mid(head);
+    return 0;
+}


### PR DESCRIPTION
Finding middle element of linked list using a mid pointer pointing to head and a counter=0 and the entire linked list is traversed in such a way that the mid pointer moves forward only when count is odd. In this way the mid pointer will point to the middle element after the whole linked list is traversed.